### PR TITLE
spore: display the image of minted nft after minting

### DIFF
--- a/apps/spore/src/routes/_app.mint.lazy.tsx
+++ b/apps/spore/src/routes/_app.mint.lazy.tsx
@@ -2,11 +2,8 @@ import { createLazyFileRoute } from '@tanstack/react-router'
 import Button from '~/components/Button'
 import ProfileImg from '~/components/ProfileImg'
 import {
-  // GetSignatureRequest,
-  // GetSignatureResponse,
   MintRequest,
   useCreateAccount,
-  // useGetSignature,
   useMint,
   Network,
 } from '@/hooks/useSuave'
@@ -36,7 +33,6 @@ function Mint() {
   const [accountId, setAccountId] = useState<string>('')
   const [faAddress, setFaAddress] = useState<string>('')
   const [recipientAddress, setRecipientAddress] = useState<string>('')
-  // const [signature, setSignature] = useState<GetSignatureResponse | null>(null)
   const [mintTxHash, setMintTxHash] = useState<string>('')
   const [mintTxHashBase, setMintTxHashBase] = useState<string>('')
   const [mintButtonStatus, setMintButtonStatus] = useState<
@@ -44,8 +40,6 @@ function Mint() {
   >('idle')
   const { mutateAsync: createAccount, isPending: createAccountPending } =
     useCreateAccount()
-  // const { mutateAsync: getSignature, isPending: getSignaturePending } =
-  //   useGetSignature()
   const { mutateAsync: mint, isPending: mintPending } = useMint()
 
   const sepolia = { id: 11155111 }
@@ -82,19 +76,6 @@ function Mint() {
       }
     }
   }
-
-  // async function handleSignMintRequest() {
-  //   if (!accountId || !recipientAddress) {
-  //     console.error('Invalid accountId or recipientAddress')
-  //     return
-  //   }
-  //   const body: GetSignatureRequest = {
-  //     recipient: recipientAddress,
-  //     accountId,
-  //   }
-  //   const signature: GetSignatureResponse = await getSignature(body)
-  //   setSignature(signature)
-  // }
 
   async function handleMintNFT() {
     if (!accountId) {
@@ -141,11 +122,6 @@ function Mint() {
               🔗 Rigil Testnet Chain info
             </a>
           </div>
-          {/* <p className="text-center text-sm px-8 pt-4">
-            <strong>
-              Please make sure you have enough SepETH in your TA to mint NFT.
-            </strong>
-          </p> */}
           <p className="text-center text-sm px-8 pt-4">
             <strong>
               This feature is in alpha. Specifications may change suddenly.
@@ -248,7 +224,6 @@ function Mint() {
               )}
             </li>
             <li>
-              {/* Sign mint request */}
               Mint NFT
               <input
                 type="text"
@@ -278,23 +253,6 @@ function Mint() {
                     Invalid Ethereum address format
                   </p>
                 )}
-              {/* <Button
-                className="btn bg-secondary w-full h-14 mt-2"
-                onClick={async () => await handleSignMintRequest()}
-                disabled={
-                  !accountId ||
-                  !receiptSuccess ||
-                  !recipientAddress ||
-                  !/^0x[a-fA-F0-9]{40}$/.test(recipientAddress)
-                }
-                isLoading={getSignaturePending}
-                success={!!signature}
-              >
-                Sign
-              </Button> */}
-              {/* </li>
-            <li> */}
-              {/* Mint NFT */}
               <Button
                 className="btn bg-secondary w-full h-14 mt-2"
                 onClick={async () => await handleMintNFT()}

--- a/apps/spore/src/routes/_app.mint.lazy.tsx
+++ b/apps/spore/src/routes/_app.mint.lazy.tsx
@@ -282,7 +282,7 @@ function Mint() {
                       <div className="md:w-1/3 w-1/2">
                         <ProfileImg rank={1} />
                       </div>
-                      <div className="md:w-1/3 w-1/2 md:text-xl font-bold pl-4">
+                      <div className="md:w-1/3  md:text-xl font-bold md:pl-4">
                         <span role="img" aria-label="success">
                           ✅ Minted!
                         </span>{' '}

--- a/apps/spore/src/routes/_app.mint.lazy.tsx
+++ b/apps/spore/src/routes/_app.mint.lazy.tsx
@@ -1,5 +1,6 @@
 import { createLazyFileRoute } from '@tanstack/react-router'
 import Button from '~/components/Button'
+import ProfileImg from '~/components/ProfileImg'
 import {
   // GetSignatureRequest,
   // GetSignatureResponse,
@@ -319,12 +320,16 @@ function Mint() {
                     </p>
                   )}
                   {mintTxHash && mintTxHashBase && (
-                    <p>
-                      <span role="img" aria-label="success">
-                        ✅
-                      </span>{' '}
-                      Minted NFT!
-                    </p>
+                    <div className="flex flex-col md:flex-row md:m-4 md:mb-6 justify-center items-center">
+                      <div className="md:w-1/3 w-1/2">
+                        <ProfileImg rank={1} />
+                      </div>
+                      <div className="md:w-1/3 w-1/2 md:text-xl font-bold pl-4">
+                        <span role="img" aria-label="success">
+                          ✅ Minted!
+                        </span>{' '}
+                      </div>
+                    </div>
                   )}
                   <p>
                     <div>


### PR DESCRIPTION
### Mobile
<img width="300" alt="Screenshot 2024-07-11 at 1 29 00" src="https://github.com/mycel-labs/frontend/assets/45069709/309a610e-ec9b-451a-9b03-2bc5995c5e6a">

### PC
<img width="600" alt="Screenshot 2024-07-11 at 1 29 22" src="https://github.com/mycel-labs/frontend/assets/45069709/88027fef-8c8b-4f84-abaa-bbbed4bf7c34">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the minting process by removing unnecessary signature request and response logic.
  - Streamlined state management for a more efficient minting operation.
  - Improved button handling for minting NFTs.

- **UI Changes**
  - Updated UI elements to provide clearer feedback during the minting process.
  - Enhanced user experience by ensuring responsive and intuitive button functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->